### PR TITLE
Implement Framers

### DIFF
--- a/pkg/serializer/encode.go
+++ b/pkg/serializer/encode.go
@@ -1,8 +1,6 @@
 package serializer
 
 import (
-	"fmt"
-
 	"github.com/weaveworks/libgitops/pkg/util"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -69,14 +67,12 @@ func (e *encoder) Encode(fw FrameWriter, objs ...runtime.Object) error {
 		}
 
 		// If the object is internal, convert it to the preferred external one
-		fmt.Printf("GVK before: %s\n", gvk)
 		if gvk.Version == runtime.APIVersionInternal {
 			gvk, err = externalGVKForObject(e.scheme, obj)
 			if err != nil {
 				return err
 			}
 		}
-		fmt.Printf("GVK after: %s\n", gvk)
 
 		// Encode it
 		if err := e.EncodeForGroupVersion(fw, obj, gvk.GroupVersion()); err != nil {

--- a/pkg/serializer/error_structs.go
+++ b/pkg/serializer/error_structs.go
@@ -1,0 +1,47 @@
+package serializer
+
+var _ ReadCloser = &errReadCloser{}
+
+type errReadCloser struct {
+	err error
+}
+
+func (rc *errReadCloser) Read(p []byte) (n int, err error) {
+	err = rc.err
+	return
+}
+
+func (rc *errReadCloser) Close() error {
+	return nil
+}
+
+var _ FrameReader = &errFrameReader{}
+
+type errFrameReader struct {
+	err         error
+	contentType ContentType
+}
+
+func (fr *errFrameReader) ReadFrame() ([]byte, error) {
+	return nil, fr.err
+}
+
+func (fr *errFrameReader) ContentType() ContentType {
+	return fr.contentType
+}
+
+var _ FrameWriter = &errFrameWriter{}
+
+type errFrameWriter struct {
+	err         error
+	contentType ContentType
+}
+
+func (fw *errFrameWriter) Write(_ []byte) (n int, err error) {
+	err = fw.err
+	return
+}
+
+func (fw *errFrameWriter) ContentType() ContentType {
+	return fw.contentType
+}

--- a/pkg/serializer/error_structs.go
+++ b/pkg/serializer/error_structs.go
@@ -30,6 +30,11 @@ func (fr *errFrameReader) ContentType() ContentType {
 	return fr.contentType
 }
 
+// Close implements io.Closer and closes the underlying ReadCloser
+func (fr *errFrameReader) Close() error {
+	return nil
+}
+
 var _ FrameWriter = &errFrameWriter{}
 
 type errFrameWriter struct {

--- a/pkg/serializer/frame_reader.go
+++ b/pkg/serializer/frame_reader.go
@@ -30,6 +30,7 @@ type ReadCloser io.ReadCloser
 // When io.EOF is reached, the stream is closed automatically.
 type FrameReader interface {
 	ContentTyped
+	io.Closer
 
 	// ReadFrame reads frames from the underlying ReadCloser and returns them for consumption.
 	// When io.EOF is reached, the stream is closed automatically.
@@ -144,6 +145,11 @@ func (rf *frameReader) ReadFrame() (frame []byte, err error) {
 // ContentType returns the content type for the given FrameReader
 func (rf *frameReader) ContentType() ContentType {
 	return rf.contentType
+}
+
+// Close implements io.Closer and closes the underlying ReadCloser
+func (rf *frameReader) Close() error {
+	return rf.rc.Close()
 }
 
 // FromFile returns a ReadCloser from the given file, or a ReadCloser which returns

--- a/pkg/serializer/frame_reader.go
+++ b/pkg/serializer/frame_reader.go
@@ -1,0 +1,160 @@
+package serializer
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+)
+
+const (
+	defaultBufSize      = 64 * 1024        // 64 kB
+	defaultMaxFrameSize = 16 * 1024 * 1024 // 16 MB
+)
+
+var (
+	// FrameOverflowErr is returned from FrameReader.ReadFrame when one frame exceeds the
+	// maximum size of 16 MB.
+	FrameOverflowErr = errors.New("frame was larger than maximum allowed size")
+)
+
+// ReadCloser in this package is an alias for io.ReadCloser. It helps in Godoc to locate
+// helpers in this package which returns writers (i.e. FromFile and FromBytes)
+type ReadCloser io.ReadCloser
+
+// FrameReader is a content-type specific reader of a given ReadCloser.
+// The FrameReader reads frames from the underlying ReadCloser and returns them for consumption.
+// When io.EOF is reached, the stream is closed automatically.
+type FrameReader interface {
+	ContentTyped
+
+	// ReadFrame reads frames from the underlying ReadCloser and returns them for consumption.
+	// When io.EOF is reached, the stream is closed automatically.
+	ReadFrame() ([]byte, error)
+}
+
+// NewFrameReader returns a FrameReader for the given ContentType and data in the
+// ReadCloser. The Reader is automatically closed in io.EOF. ReadFrame is called
+// once each Decoder.Decode() or Decoder.DecodeInto() call. When Decoder.DecodeAll() is
+// called, the FrameReader is read until io.EOF, upon where it is closed.
+func NewFrameReader(contentType ContentType, rc ReadCloser) FrameReader {
+	switch contentType {
+	case ContentTypeYAML:
+		return newFrameReader(json.YAMLFramer.NewFrameReader(rc), contentType)
+	case ContentTypeJSON:
+		return newFrameReader(json.Framer.NewFrameReader(rc), contentType)
+	default:
+		return &errFrameReader{ErrUnsupportedContentType, contentType}
+	}
+}
+
+// NewYAMLFrameReader returns a FrameReader that supports both YAML and JSON. Frames are separated by "---\n"
+//
+// This call is the same as NewFrameReader(ContentTypeYAML, rc)
+func NewYAMLFrameReader(rc ReadCloser) FrameReader {
+	return NewFrameReader(ContentTypeYAML, rc)
+}
+
+// NewJSONFrameReader returns a FrameReader that supports both JSON. Objects are read from the stream one-by-one,
+// each object making up its own frame.
+//
+// This call is the same as NewFrameReader(ContentTypeJSON, rc)
+func NewJSONFrameReader(rc ReadCloser) FrameReader {
+	return NewFrameReader(ContentTypeJSON, rc)
+}
+
+// newFrameReader returns a new instance of the frameReader struct
+func newFrameReader(rc io.ReadCloser, contentType ContentType) *frameReader {
+	return &frameReader{
+		rc:           rc,
+		bufSize:      defaultBufSize,
+		maxFrameSize: defaultMaxFrameSize,
+		contentType:  contentType,
+	}
+}
+
+// frameReader is a FrameReader implementation
+type frameReader struct {
+	rc           io.ReadCloser
+	bufSize      int
+	maxFrameSize int
+	contentType  ContentType
+}
+
+// ReadFrame reads one frame from the underlying io.Reader. ReadFrame
+// keeps on reading from the Reader in bufSize blocks, until the Reader either
+// returns err == nil or EOF. If the Reader reports an ErrShortBuffer error,
+// ReadFrame keeps on reading using new calls. ReadFrame might return both data and
+// io.EOF. io.EOF will be returned in the final call.
+func (rf *frameReader) ReadFrame() (frame []byte, err error) {
+	// Temporary buffer to parts of a frame into
+	var buf []byte
+	// How many bytes were read by the read call
+	var n int
+	// Multiplier for bufsize
+	c := 1
+	for {
+		// Allocate a buffer of a multiple of bufSize.
+		buf = make([]byte, c*rf.bufSize)
+		// Call the underlying reader.
+		n, err = rf.rc.Read(buf)
+		// Append the returned bytes to the b slice returned
+		// If n is 0, this call is a no-op
+		frame = append(frame, buf[:n]...)
+
+		// If the frame got bigger than the max allowed size, return and report the error
+		if len(frame) > rf.maxFrameSize {
+			err = FrameOverflowErr
+			return
+		}
+
+		// Handle different kinds of errors
+		switch err {
+		case io.ErrShortBuffer:
+			// ignore the "buffer too short" error, and just keep on reading, now doubling the buffer
+			c *= 2
+			continue
+		case nil:
+			// One document is "done reading", we should return it if valid
+			// Only return non-empty documents, i.e. skip e.g. leading `---`
+			if len(bytes.TrimSpace(frame)) > 0 {
+				// valid non-empty document
+				return
+			}
+			// The document was empty, reset the frame (just to be sure) and continue
+			frame = nil
+			continue
+		case io.EOF:
+			// we reached the end of the file, close the reader and return
+			rf.rc.Close()
+			return
+		default:
+			// unknown error, return it immediately
+			// TODO: Maybe return the error here?
+			return
+		}
+	}
+}
+
+// ContentType returns the content type for the given FrameReader
+func (rf *frameReader) ContentType() ContentType {
+	return rf.contentType
+}
+
+// FromFile returns a ReadCloser from the given file, or a ReadCloser which returns
+// the given file open error when read.
+func FromFile(filePath string) ReadCloser {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return &errReadCloser{err}
+	}
+	return f
+}
+
+// FromBytes returns a ReadCloser from the given byte content.
+func FromBytes(content []byte) ReadCloser {
+	return ioutil.NopCloser(bytes.NewReader(content))
+}

--- a/pkg/serializer/frame_reader.go
+++ b/pkg/serializer/frame_reader.go
@@ -82,6 +82,8 @@ type frameReader struct {
 	bufSize      int
 	maxFrameSize int
 	contentType  ContentType
+
+	// TODO: Maybe add mutexes for thread-safety (so no two goroutines read at the same time)
 }
 
 // ReadFrame reads one frame from the underlying io.Reader. ReadFrame

--- a/pkg/serializer/frame_reader_test.go
+++ b/pkg/serializer/frame_reader_test.go
@@ -1,0 +1,114 @@
+package serializer
+
+import (
+	"io"
+	"io/ioutil"
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+)
+
+const (
+	fooYAML = `kind: Foo
+apiVersion: bar/v1
+a: b1234567890
+c: d1234567890
+e: f1234567890
+hello: true`
+
+	barYAML = `kind: Bar
+apiVersion: foo/v1
+a: b1234567890
+c: d1234567890
+e: f1234567890
+hello: false`
+
+	bazYAML = `baz: true`
+
+	testYAML = "\n---\n" + fooYAML + "\n---\n" + barYAML + "\n---\n" + bazYAML
+)
+
+func Test_FrameReader_ReadFrame(t *testing.T) {
+	testYAMLReadCloser := json.YAMLFramer.NewFrameReader(ioutil.NopCloser(strings.NewReader(testYAML)))
+
+	type fields struct {
+		rc           io.ReadCloser
+		bufSize      int
+		maxFrameSize int
+	}
+	type result struct {
+		wantB   []byte
+		wantErr bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		wants  []result
+	}{
+		{
+			name: "three-document YAML case",
+			fields: fields{
+				rc:           testYAMLReadCloser,
+				bufSize:      16,
+				maxFrameSize: 1024,
+			},
+			wants: []result{
+				{
+					wantB:   []byte(fooYAML),
+					wantErr: false,
+				},
+				{
+					wantB:   []byte(barYAML),
+					wantErr: false,
+				},
+				{
+					wantB:   []byte(bazYAML),
+					wantErr: false,
+				},
+				{
+					wantB:   nil,
+					wantErr: true,
+				},
+			},
+		},
+		{
+			name: "maximum size reached",
+			fields: fields{
+				rc:           testYAMLReadCloser,
+				bufSize:      16,
+				maxFrameSize: 32,
+			},
+			wants: []result{
+				{
+					wantB:   nil,
+					wantErr: true,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rf := &frameReader{
+				rc:           tt.fields.rc,
+				bufSize:      tt.fields.bufSize,
+				maxFrameSize: tt.fields.maxFrameSize,
+			}
+			for _, expected := range tt.wants {
+				gotB, err := rf.ReadFrame()
+				if (err != nil) != expected.wantErr {
+					t.Errorf("frameReader.ReadFrame() error = %v, wantErr %v", err, expected.wantErr)
+					return
+				}
+				if len(gotB) < len(expected.wantB) {
+					t.Errorf("frameReader.ReadFrame(): got smaller slice %v than expected %v", gotB, expected.wantB)
+					return
+				}
+				if !reflect.DeepEqual(gotB[:len(expected.wantB)], expected.wantB) {
+					t.Errorf("frameReader.ReadFrame() = %v, want %v", gotB, expected.wantB)
+				}
+			}
+		})
+	}
+}

--- a/pkg/serializer/frame_writer.go
+++ b/pkg/serializer/frame_writer.go
@@ -55,6 +55,8 @@ type frameWriter struct {
 	Writer
 
 	contentType ContentType
+
+	// TODO: Maybe add mutexes for thread-safety (so no two goroutines write at the same time)
 }
 
 // ContentType returns the content type for the given FrameWriter

--- a/pkg/serializer/frame_writer.go
+++ b/pkg/serializer/frame_writer.go
@@ -1,0 +1,126 @@
+package serializer
+
+import (
+	"io"
+)
+
+const (
+	yamlSeparator = "---\n"
+)
+
+// Writer in this package is an alias for io.Writer. It helps in Godoc to locate
+// helpers in this package which returns writers (i.e. ToBytes)
+type Writer io.Writer
+
+// FrameWriter is a ContentType-specific io.Writer that writes given frames in an applicable way
+// to an underlying io.Writer stream
+type FrameWriter interface {
+	ContentTyped
+	Writer
+}
+
+// NewFrameWriter returns a new FrameWriter for the given Writer and ContentType
+func NewFrameWriter(contentType ContentType, w Writer) FrameWriter {
+	switch contentType {
+	case ContentTypeYAML:
+		// Use our own implementation of the underlying YAML FrameWriter
+		return &frameWriter{newYAMLWriter(w), contentType}
+	case ContentTypeJSON:
+		// Comment from k8s.io/apimachinery/pkg/runtime/serializer/json.Framer.NewFrameWriter:
+		// "we can write JSON objects directly to the writer, because they are self-framing"
+		// Hence, we directly use w without any modifications.
+		return &frameWriter{w, contentType}
+	default:
+		return &errFrameWriter{ErrUnsupportedContentType, contentType}
+	}
+}
+
+// NewYAMLFrameWriter returns a FrameWriter that writes YAML frames separated by "---\n"
+//
+// This call is the same as NewFrameWriter(ContentTypeYAML, w)
+func NewYAMLFrameWriter(w Writer) FrameWriter {
+	return NewFrameWriter(ContentTypeYAML, w)
+}
+
+// NewJSONFrameWriter returns a FrameWriter that writes JSON frames without separation
+// (i.e. "{ ... }{ ... }{ ... }" on the wire)
+//
+// This call is the same as NewFrameWriter(ContentTypeYAML, w)
+func NewJSONFrameWriter(w Writer) FrameWriter {
+	return NewFrameWriter(ContentTypeJSON, w)
+}
+
+// frameWriter is an implementation of the FrameWriter interface
+type frameWriter struct {
+	Writer
+
+	contentType ContentType
+}
+
+// ContentType returns the content type for the given FrameWriter
+func (wf *frameWriter) ContentType() ContentType {
+	return wf.contentType
+}
+
+// newYAMLWriter returns a new yamlWriter implementation
+func newYAMLWriter(w Writer) *yamlWriter {
+	return &yamlWriter{
+		w:          w,
+		hasWritten: false,
+	}
+}
+
+// yamlWriter writes yamlSeparator between documents
+type yamlWriter struct {
+	w          io.Writer
+	hasWritten bool
+}
+
+// Write implements io.Writer
+func (w *yamlWriter) Write(p []byte) (n int, err error) {
+	// If we've already written some documents, add the separator in between
+	if w.hasWritten {
+		_, err = w.w.Write([]byte(yamlSeparator))
+		if err != nil {
+			return
+		}
+	}
+
+	// Write the given bytes to the underlying writer
+	n, err = w.w.Write(p)
+	if err != nil {
+		return
+	}
+
+	// Mark that we've now written once and should write the separator in between
+	w.hasWritten = true
+	return
+}
+
+// ToBytes returns a Writer which can be passed to NewFrameWriter. The Writer writes directly
+// to an underlying byte array. The byte array must be of enough length in order to write.
+func ToBytes(p []byte) Writer {
+	return &byteWriter{p, 0}
+}
+
+type byteWriter struct {
+	to []byte
+	// the next index to write to
+	index int
+}
+
+func (w *byteWriter) Write(from []byte) (n int, err error) {
+	// Check if we have space in to, in order to write bytes there
+	if w.index+len(from) > len(w.to) {
+		err = io.ErrShortBuffer
+		return
+	}
+	// Copy over the bytes one by one
+	for i := range from {
+		w.to[w.index+i] = from[i]
+	}
+	// Increase the index for the next Write call's target position
+	w.index += len(from)
+	n += len(from)
+	return
+}

--- a/pkg/serializer/frame_writer_test.go
+++ b/pkg/serializer/frame_writer_test.go
@@ -1,0 +1,66 @@
+package serializer
+
+import (
+	"bytes"
+	"testing"
+)
+
+func Test_byteWriter_Write(t *testing.T) {
+	type fields struct {
+		to    []byte
+		index int
+	}
+	type args struct {
+		from []byte
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantN   int
+		wantErr bool
+	}{
+		{
+			name: "simple case",
+			fields: fields{
+				to: make([]byte, 50),
+			},
+			args: args{
+				from: []byte("Hello!\nFoobar"),
+			},
+			wantN:   13,
+			wantErr: false,
+		},
+		{
+			name: "target too short",
+			fields: fields{
+				to: make([]byte, 10),
+			},
+			args: args{
+				from: []byte("Hello!\nFoobar"),
+			},
+			wantN:   0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &byteWriter{
+				to:    tt.fields.to,
+				index: tt.fields.index,
+			}
+			gotN, err := w.Write(tt.args.from)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("byteWriter.Write() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotN != tt.wantN {
+				t.Errorf("byteWriter.Write() = %v, want %v", gotN, tt.wantN)
+				return
+			}
+			if !tt.wantErr && !bytes.Equal(tt.fields.to[:gotN], tt.args.from) {
+				t.Errorf("byteWriter.Write(): expected fields.to (%s) to equal args.from (%s), but didn't", tt.fields.to[:gotN], tt.args.from)
+			}
+		})
+	}
+}

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -1,76 +1,48 @@
 package serializer
 
 import (
-	"bytes"
+	"errors"
 	"fmt"
-	"io"
-	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
-func newReaderWithClose(r io.Reader) ReadCloser {
-	return &readerWithClose{r}
-}
-
-type readerWithClose struct {
-	io.Reader
-}
-
-func (readerWithClose) Close() error {
-	return nil
-}
-
-type ReadCloser io.ReadCloser
-
-func FromFile(filePath string) ReadCloser {
-	f, err := os.Open(filePath)
-	if err != nil {
-		return &errReadCloser{err}
-	}
-	return f
-}
-
-func FromBytes(content []byte) ReadCloser {
-	return newReaderWithClose(bytes.NewReader(content))
-}
-
-var _ ReadCloser = &errReadCloser{}
-
-type errReadCloser struct {
-	err error
-}
-
-func (rc *errReadCloser) Read(p []byte) (n int, err error) {
-	err = rc.err
-	return
-}
-
-func (rc *errReadCloser) Close() error {
-	return nil
-}
-
+// ContentType specifies a content type for Encoders, Decoders, FrameWriters and FrameReaders
 type ContentType string
 
 const (
-	ContentTypeJSON ContentType = ContentType(runtime.ContentTypeJSON)
-	ContentTypeYAML ContentType = ContentType(runtime.ContentTypeYAML)
+	// ContentTypeJSON specifies usage of JSON as the content type.
+	// It is an alias for k8s.io/apimachinery/pkg/runtime.ContentTypeJSON
+	ContentTypeJSON = ContentType(runtime.ContentTypeJSON)
+
+	// ContentTypeYAML specifies usage of YAML as the content type.
+	// It is an alias for k8s.io/apimachinery/pkg/runtime.ContentTypeYAML
+	ContentTypeYAML = ContentType(runtime.ContentTypeYAML)
 )
+
+// ErrUnsupportedContentType is returned if the specified content type isn't supported
+var ErrUnsupportedContentType = errors.New("unsupported content type")
+
+// ContentTyped is an interface for objects that are specific to a set ContentType.
+type ContentTyped interface {
+	// ContentType returns the ContentType (usually ContentTypeYAML or ContentTypeJSON) for the given object.
+	ContentType() ContentType
+}
 
 // Serializer is an interface providing high-level decoding/encoding functionality
 // for types registered in a *runtime.Scheme
 type Serializer interface {
-	// Decoder returns a decoder with the given options and reader. You may use helper functions
-	// FromBytes and FromFile to decode from a file or byte slice. The decoder should be closed
-	// after use.
-	Decoder(rc ReadCloser, optsFn ...DecodingOptionsFunc) Decoder
+	// Decoder is a high-level interface for decoding Kubernetes API Machinery objects read from
+	// a FrameWriter. The decoder can be customized by passing some options (e.g. WithDecodingOptions)
+	// to this call.
+	Decoder(optsFn ...DecodingOptionsFunc) Decoder
 
-	// Encoder returns an encoder for the specified content type and options. Encode functions return bytes, but
-	// there's also the option to write all encoded content during the lifetime of the encoder to a writer using
-	// WithEncodeWriter(io.Writer) in the options.
-	Encoder(contentType ContentType, optsFn ...EncodingOptionsFunc) Encoder
+	// Encoder is a high-level interface for encoding Kubernetes API Machinery objects and writing them
+	// to a FrameWriter. The encoder can be customized by passing some options (e.g. WithEncodingOptions)
+	// to this call.
+	Encoder(optsFn ...EncodingOptionsFunc) Encoder
 
 	// DefaultInternal populates the given internal object with the preferred external version's defaults
 	// TODO: Make Defaulter() interface
@@ -85,57 +57,69 @@ type schemeAndCodec struct {
 	codecs *k8sserializer.CodecFactory
 }
 
+// Encoder is a high-level interface for encoding Kubernetes API Machinery objects and writing them
+// to a FrameWriter.
 type Encoder interface {
-	// Encode returns the objects in the specified encoded format. In case multiple objects are
-	// provided, the encoder will specify behavior. For YAML, multiple documents will be written. For
-	// JSON, this call will error. This encoder will choose the preferred external groupversion automatically.
-	Encode(obj ...runtime.Object) ([]byte, error)
+	// Encode encodes the given objects and writes them to the specified FrameWriter.
+	// The FrameWriter specifies the ContentType. This encoder will automatically convert any
+	// internal object given to the preferred external groupversion. No conversion will happen
+	// if the given object is of an external version.
+	Encode(fw FrameWriter, obj ...runtime.Object) error
 
-	// TODO: Maybe add this?
-	// EncodeForGroupVersion(obj runtime.Object, gv schema.GroupVersion) ([]byte, error)
+	// EncodeForGroupVersion encodes the given object for the specific groupversion. If the object
+	// is not of that version currently it will try to convert. The output bytes are written to the
+	// FrameWriter. The FrameWriter specifies the ContentType.
+	EncodeForGroupVersion(fw FrameWriter, obj runtime.Object, gv schema.GroupVersion) error
 }
 
+// Decoder is a high-level interface for decoding Kubernetes API Machinery objects read from
+// a FrameWriter. The decoder can be customized by passing some options (e.g. WithDecodingOptions)
+// to this call.
 type Decoder interface {
-	// Decode returns the decoded object from the next document in the stream.
+	// Decode returns the decoded object from the next document in the FrameReader stream.
 	// If there are multiple documents in the underlying stream, this call will read one
 	// 	document and return it. Decode might be invoked for getting new documents until it
 	// 	returns io.EOF. When io.EOF is reached in a call, the stream is automatically closed.
+	// If the decoded object is for an unrecognized group, or version, UnrecognizedGroupError
+	// 	or UnrecognizedVersionError might be returned.
 	// If opts.Default is true, the decoded object will be defaulted.
-	// If opts.Strict is true, the YAML/JSON will be parsed in strict mode, returning a specific error (TODO)
-	// 	if the input contains duplicate or unknown fields or formatting errors
+	// If opts.Strict is true, the YAML/JSON will be parsed in strict mode, returning a specific error
+	// 	if the input contains duplicate or unknown fields or formatting errors. You can check whether
+	// 	a returned failed because of the strictness using k8s.io/apimachinery/pkg/runtime.IsStrictDecodingError.
 	// If opts.Internal is true, the decoded external object will be converted into its internal representation.
 	// 	Otherwise, the decoded object will be left in the external representation.
-	// opts.DecodeListElements is not applicable in this call. If the underlying data contains a v1.List,
-	// 	decoding will be successfully performed and a v1.List is returned.
-	// TODO: Mention UnrecognizedGroupError and UnrecognizedVersionError
-	Decode() (runtime.Object, error)
-	// DecodeInto decodes the next document in the stream into obj if the types are matching.
+	// opts.DecodeListElements is not applicable in this call.
+	Decode(fr FrameReader) (runtime.Object, error)
+	// DecodeInto decodes the next document in the FrameReader stream into obj if the types are matching.
 	// If there are multiple documents in the underlying stream, this call will read one
 	// 	document and return it. Decode might be invoked for getting new documents until it
 	// 	returns io.EOF. When io.EOF is reached in a call, the stream is automatically closed.
+	// The decoded object will automatically be converted into the target one (i.e. one can supply an
+	// 	internal object to this function).
+	// If the decoded object is for an unrecognized group, or version, UnrecognizedGroupError
+	// 	or UnrecognizedVersionError might be returned.
 	// If opts.Default is true, the decoded object will be defaulted.
-	// If opts.Strict is true, the YAML/JSON will be parsed in strict mode, returning a specific error (TODO)
-	// 	if the input contains duplicate or unknown fields or formatting errors
-	// opts.DecodeListElements is not applicable in this call. If a v1.List is given as obj, and the
-	// 	underlying data contains a v1.List, decoding will be successfully performed.
+	// If opts.Strict is true, the YAML/JSON will be parsed in strict mode, returning a specific error
+	// 	if the input contains duplicate or unknown fields or formatting errors. You can check whether
+	// 	a returned failed because of the strictness using k8s.io/apimachinery/pkg/runtime.IsStrictDecodingError.
+	// opts.DecodeListElements is not applicable in this call.
 	// opts.Internal is not applicable in this call.
-	DecodeInto(obj runtime.Object) error
+	DecodeInto(fr FrameReader, obj runtime.Object) error
 
-	// DecodeAll returns the decoded objects from all documents in the stream. The underlying
+	// DecodeAll returns the decoded objects from all documents in the FrameReader stream. The underlying
 	// stream is automatically closed on io.EOF. io.EOF is never returned from this function.
+	// If any decoded object is for an unrecognized group, or version, UnrecognizedGroupError
+	// 	or UnrecognizedVersionError might be returned.
 	// If opts.Default is true, the decoded objects will be defaulted.
-	// If opts.Strict is true, the YAML/JSON will be parsed in strict mode, returning a specific error (TODO)
-	// 	if the input contains duplicate or unknown fields or formatting errors
+	// If opts.Strict is true, the YAML/JSON will be parsed in strict mode, returning a specific error
+	// 	if the input contains duplicate or unknown fields or formatting errors. You can check whether
+	// 	a returned failed because of the strictness using k8s.io/apimachinery/pkg/runtime.IsStrictDecodingError.
 	// If opts.Internal is true, the decoded external object will be converted into their internal representation.
 	// 	Otherwise, the decoded objects will be left in their external representation.
 	// If opts.DecodeListElements is true and the underlying data contains a v1.List,
 	// 	the items of the list will be traversed and decoded into their respective types, which are
 	// 	added into the returning slice. The v1.List will in this case not be returned.
-	DecodeAll() ([]runtime.Object, error)
-
-	// Close implements io.Closer. If close is called, the underlying stream is also closed. After
-	// Close() has been called, all future Decode operations will return an error.
-	Close() error
+	DecodeAll(fr FrameReader) ([]runtime.Object, error)
 }
 
 // NewSerializer constructs a new serializer based on a scheme, and optionally a codecfactory
@@ -167,19 +151,21 @@ func (s *serializer) Scheme() *runtime.Scheme {
 	return s.scheme
 }
 
-func (s *serializer) Decoder(rc ReadCloser, optFns ...DecodingOptionsFunc) Decoder {
+func (s *serializer) Decoder(optFns ...DecodingOptionsFunc) Decoder {
 	opts := newDecodeOpts(optFns...)
-	return newDecoder(s.schemeAndCodec, rc, *opts)
+	return newDecoder(s.schemeAndCodec, *opts)
 }
 
-func (s *serializer) Encoder(contentType ContentType, optFns ...EncodingOptionsFunc) Encoder {
+func (s *serializer) Encoder(optFns ...EncodingOptionsFunc) Encoder {
 	opts := newEncodeOpts(optFns...)
-	return newEncoder(s.schemeAndCodec, contentType, *opts)
+	return newEncoder(s.schemeAndCodec, *opts)
 }
+
+var ErrObjectNotInternal = errors.New("given object is of an internal version")
 
 // DefaultInternal populates the given internal object with the preferred external version's defaults
 func (s *serializer) DefaultInternal(cfg runtime.Object) error {
-	gvk, err := s.externalGVKForObject(cfg)
+	gvk, err := externalGVKForObject(s.scheme, cfg)
 	if err != nil {
 		return err
 	}
@@ -194,19 +180,35 @@ func (s *serializer) DefaultInternal(cfg runtime.Object) error {
 	return s.scheme.Convert(external, cfg, nil)
 }
 
-func (s *serializer) externalGVKForObject(cfg runtime.Object) (*schema.GroupVersionKind, error) {
-	gvks, unversioned, err := s.scheme.ObjectKinds(cfg)
-	if unversioned || err != nil || len(gvks) != 1 {
-		return nil, fmt.Errorf("unversioned %t or err %v or invalid gvks %v", unversioned, err, gvks)
+// externalGVKForObject returns the preferred external groupversion for an internal object
+// If the object is not internal, ErrObjectNotInternal is returned
+func externalGVKForObject(scheme *runtime.Scheme, cfg runtime.Object) (*schema.GroupVersionKind, error) {
+	// Get the GVK
+	gvk, err := gvkForObject(scheme, cfg)
+	if err != nil {
+		return nil, err
 	}
 
-	gvk := gvks[0]
-	gvs := s.scheme.PrioritizedVersionsForGroup(gvk.Group)
+	// Require the object to be internal
+	if gvk.Version != runtime.APIVersionInternal {
+		return nil, ErrObjectNotInternal
+	}
+
+	// Get the prioritized versions for the given group
+	gvs := scheme.PrioritizedVersionsForGroup(gvk.Group)
 	if len(gvs) < 1 {
 		return nil, fmt.Errorf("expected some version to be registered for group %s", gvk.Group)
 	}
 
 	// Use the preferred (external) version
 	gvk.Version = gvs[0].Version
-	return &gvk, nil
+	return gvk, nil
+}
+
+func gvkForObject(scheme *runtime.Scheme, cfg runtime.Object) (*schema.GroupVersionKind, error) {
+	gvks, unversioned, err := scheme.ObjectKinds(cfg)
+	if unversioned || err != nil || len(gvks) != 1 {
+		return nil, fmt.Errorf("unversioned %t or err %v or invalid gvks %v", unversioned, err, gvks)
+	}
+	return &gvks[0], nil
 }

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -161,7 +161,7 @@ func (s *serializer) Encoder(optFns ...EncodingOptionsFunc) Encoder {
 	return newEncoder(s.schemeAndCodec, *opts)
 }
 
-var ErrObjectNotInternal = errors.New("given object is of an internal version")
+var ErrObjectNotInternal = errors.New("given object is not an internal version")
 
 // DefaultInternal populates the given internal object with the preferred external version's defaults
 func (s *serializer) DefaultInternal(cfg runtime.Object) error {

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -169,7 +169,7 @@ func (s *serializer) DefaultInternal(cfg runtime.Object) error {
 	if err != nil {
 		return err
 	}
-	external, err := s.scheme.New(*gvk)
+	external, err := s.scheme.New(gvk)
 	if err != nil {
 		return nil
 	}
@@ -182,22 +182,22 @@ func (s *serializer) DefaultInternal(cfg runtime.Object) error {
 
 // externalGVKForObject returns the preferred external groupversion for an internal object
 // If the object is not internal, ErrObjectNotInternal is returned
-func externalGVKForObject(scheme *runtime.Scheme, cfg runtime.Object) (*schema.GroupVersionKind, error) {
+func externalGVKForObject(scheme *runtime.Scheme, obj runtime.Object) (schema.GroupVersionKind, error) {
 	// Get the GVK
-	gvk, err := gvkForObject(scheme, cfg)
+	gvk, err := gvkForObject(scheme, obj)
 	if err != nil {
-		return nil, err
+		return schema.GroupVersionKind{}, err
 	}
 
 	// Require the object to be internal
 	if gvk.Version != runtime.APIVersionInternal {
-		return nil, ErrObjectNotInternal
+		return schema.GroupVersionKind{}, ErrObjectNotInternal
 	}
 
 	// Get the prioritized versions for the given group
 	gvs := scheme.PrioritizedVersionsForGroup(gvk.Group)
 	if len(gvs) < 1 {
-		return nil, fmt.Errorf("expected some version to be registered for group %s", gvk.Group)
+		return schema.GroupVersionKind{}, fmt.Errorf("expected some version to be registered for group %s", gvk.Group)
 	}
 
 	// Use the preferred (external) version
@@ -205,10 +205,10 @@ func externalGVKForObject(scheme *runtime.Scheme, cfg runtime.Object) (*schema.G
 	return gvk, nil
 }
 
-func gvkForObject(scheme *runtime.Scheme, cfg runtime.Object) (*schema.GroupVersionKind, error) {
-	gvks, unversioned, err := scheme.ObjectKinds(cfg)
+func gvkForObject(scheme *runtime.Scheme, obj runtime.Object) (schema.GroupVersionKind, error) {
+	gvks, unversioned, err := scheme.ObjectKinds(obj)
 	if unversioned || err != nil || len(gvks) != 1 {
-		return nil, fmt.Errorf("unversioned %t or err %v or invalid gvks %v", unversioned, err, gvks)
+		return schema.GroupVersionKind{}, fmt.Errorf("unversioned %t or err %v or invalid gvks %v", unversioned, err, gvks)
 	}
-	return &gvks[0], nil
+	return gvks[0], nil
 }


### PR DESCRIPTION
As discussed with @twelho. This allows us to encode/decode multiple YAML documents and even files at once in a generic and extensible way.