### PR TITLE
Automatically move lost YAML comments to the top of the document

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/rjeczalik/notify v0.9.2
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/sys v0.0.0-20200610111108-226ff32320da
 	k8s.io/apimachinery v0.18.5
 	k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6

--- a/pkg/serializer/comments.go
+++ b/pkg/serializer/comments.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
+	"github.com/weaveworks/libgitops/pkg/serializer/comments"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/kustomize/kyaml/comments"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 

--- a/pkg/serializer/comments.go
+++ b/pkg/serializer/comments.go
@@ -89,8 +89,7 @@ func (e *encoder) encodeWithCommentSupport(versionEncoder runtime.Encoder, fw Fr
 	}
 
 	// Copy over comments from the old to the new schema
-	// TODO: Also preserve comments that are "lost on the way", i.e. on schema changes
-	if err := comments.CopyComments(priorNode, afterNode); err != nil {
+	if err := comments.CopyComments(priorNode, afterNode, true); err != nil {
 		// fatal error
 		return err
 	}

--- a/pkg/serializer/comments/LICENSE
+++ b/pkg/serializer/comments/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkg/serializer/comments/comments.go
+++ b/pkg/serializer/comments/comments.go
@@ -1,0 +1,92 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// This package provides a means to copyComment over comments between
+// two kyaml/yaml.RNode trees. This code is derived from
+// the sigs.k8s.io/kustomize/kyaml/comments package, at revision
+// 600d4f2c0bf174abd76d03e49939ee0c34b2a019.
+//
+// It has been slightly modified and adapted to not lose any
+// comment from the old tree, although the node the comment is
+// attached to doesn't exist in the new tree. To solve this,
+// this package moves any such comments to the beginning of the
+// file.
+// This file is a temporary means as long as we're waiting for
+// these code changes to get upstreamed to its origin, the kustomize repo.
+// https://pkg.go.dev/sigs.k8s.io/kustomize/kyaml/comments?tab=doc#CopyComments
+
+package comments
+
+import (
+	"sigs.k8s.io/kustomize/kyaml/openapi"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+	"sigs.k8s.io/kustomize/kyaml/yaml/walk"
+)
+
+// CopyComments recursively copies the comments on fields in from to fields in to
+func CopyComments(from, to *yaml.RNode) error {
+	copy(from, to)
+	// walk the fields copying comments
+	_, err := walk.Walker{
+		Sources:            []*yaml.RNode{from, to},
+		Visitor:            &copier{},
+		VisitKeysAsScalars: true}.Walk()
+	return err
+}
+
+// copier implements walk.Visitor, and copies comments to fields shared between 2 instances
+// of a resource
+type copier struct{}
+
+func (c *copier) VisitMap(s walk.Sources, _ *openapi.ResourceSchema) (*yaml.RNode, error) {
+	copy(s.Dest(), s.Origin())
+	return s.Dest(), nil
+}
+
+func (c *copier) VisitScalar(s walk.Sources, _ *openapi.ResourceSchema) (*yaml.RNode, error) {
+	to := s.Origin()
+	// TODO: File a bug with upstream yaml to handle comments for FoldedStyle scalar nodes
+	// Hack: convert FoldedStyle scalar node to DoubleQuotedStyle as the line comments are
+	// being serialized without space
+	// https://github.com/GoogleContainerTools/kpt/issues/766
+	if to != nil && to.Document().Style == yaml.FoldedStyle {
+		to.Document().Style = yaml.DoubleQuotedStyle
+	}
+
+	copy(s.Dest(), to)
+	return s.Dest(), nil
+}
+
+func (c *copier) VisitList(s walk.Sources, _ *openapi.ResourceSchema, _ walk.ListKind) (
+	*yaml.RNode, error) {
+	copy(s.Dest(), s.Origin())
+	destItems := s.Dest().Content()
+	originItems := s.Origin().Content()
+
+	for i := 0; i < len(destItems) && i < len(originItems); i++ {
+		dest := destItems[i]
+		origin := originItems[i]
+
+		if dest.Value == origin.Value {
+			copy(yaml.NewRNode(dest), yaml.NewRNode(origin))
+		}
+	}
+
+	return s.Dest(), nil
+}
+
+// copy copies the comment from one field to another
+func copy(from, to *yaml.RNode) {
+	if from == nil || to == nil {
+		return
+	}
+	if to.Document().LineComment == "" {
+		to.Document().LineComment = from.Document().LineComment
+	}
+	if to.Document().HeadComment == "" {
+		to.Document().HeadComment = from.Document().HeadComment
+	}
+	if to.Document().FootComment == "" {
+		to.Document().FootComment = from.Document().FootComment
+	}
+}

--- a/pkg/serializer/comments/comments.go
+++ b/pkg/serializer/comments/comments.go
@@ -1,7 +1,7 @@
 // Copyright 2019 The Kubernetes Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-// This package provides a means to copyComment over comments between
+// This package provides a means to copy over comments between
 // two kyaml/yaml.RNode trees. This code is derived from
 // the sigs.k8s.io/kustomize/kyaml/comments package, at revision
 // 600d4f2c0bf174abd76d03e49939ee0c34b2a019.
@@ -18,28 +18,54 @@
 package comments
 
 import (
+	"fmt"
+	"strings"
+
 	"sigs.k8s.io/kustomize/kyaml/openapi"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/kustomize/kyaml/yaml/walk"
 )
 
 // CopyComments recursively copies the comments on fields in from to fields in to
-func CopyComments(from, to *yaml.RNode) error {
-	copy(from, to)
+func CopyComments(from, to *yaml.RNode, moveCommentsTop bool) error {
+	// create the copier struct for the specified mode
+	c := &copier{moveCommentsTop, nil}
+
+	// copy over comments for the root tree(s)
+	c.copyFieldComments(from, to)
+
 	// walk the fields copying comments
 	_, err := walk.Walker{
 		Sources:            []*yaml.RNode{from, to},
-		Visitor:            &copier{},
+		Visitor:            c,
 		VisitKeysAsScalars: true}.Walk()
+
+	// restore lost comments to the top of the document, if applicable
+	if moveCommentsTop {
+		c.restoreLostComments(to)
+	}
+
 	return err
 }
 
 // copier implements walk.Visitor, and copies comments to fields shared between 2 instances
 // of a resource
-type copier struct{}
+type copier struct {
+	// moveCommentsTop specifies whether to recover lost comments or not
+	moveCommentsTop bool
+	// if moveCommentsTop is true, this slice will be populated with lost comment entries while iterating
+	lostComments []lostComment
+}
+
+// lostComment specifies a mapping between a fieldName (in the old structure) which doesn't exist in the
+// new tree, and its related comment
+type lostComment struct {
+	fieldName string
+	comment   string
+}
 
 func (c *copier) VisitMap(s walk.Sources, _ *openapi.ResourceSchema) (*yaml.RNode, error) {
-	copy(s.Dest(), s.Origin())
+	c.copyFieldComments(s.Dest(), s.Origin())
 	return s.Dest(), nil
 }
 
@@ -53,13 +79,12 @@ func (c *copier) VisitScalar(s walk.Sources, _ *openapi.ResourceSchema) (*yaml.R
 		to.Document().Style = yaml.DoubleQuotedStyle
 	}
 
-	copy(s.Dest(), to)
+	c.copyFieldComments(s.Dest(), to)
 	return s.Dest(), nil
 }
 
-func (c *copier) VisitList(s walk.Sources, _ *openapi.ResourceSchema, _ walk.ListKind) (
-	*yaml.RNode, error) {
-	copy(s.Dest(), s.Origin())
+func (c *copier) VisitList(s walk.Sources, _ *openapi.ResourceSchema, _ walk.ListKind) (*yaml.RNode, error) {
+	c.copyFieldComments(s.Dest(), s.Origin())
 	destItems := s.Dest().Content()
 	originItems := s.Origin().Content()
 
@@ -68,18 +93,26 @@ func (c *copier) VisitList(s walk.Sources, _ *openapi.ResourceSchema, _ walk.Lis
 		origin := originItems[i]
 
 		if dest.Value == origin.Value {
-			copy(yaml.NewRNode(dest), yaml.NewRNode(origin))
+			c.copyFieldComments(yaml.NewRNode(dest), yaml.NewRNode(origin))
 		}
 	}
 
 	return s.Dest(), nil
 }
 
-// copy copies the comment from one field to another
-func copy(from, to *yaml.RNode) {
+// copyFieldComments copies the comment from one field to another
+func (c *copier) copyFieldComments(from, to *yaml.RNode) {
+	// If either from or to doesn't exist, return quickly
 	if from == nil || to == nil {
+
+		// If we asked for moving lost comments (i.e. if from is non-nil and to is nil),
+		// do it through the moveLostCommentToTop function
+		if c.moveCommentsTop && from != nil && to == nil {
+			c.rememberLostComments(from)
+		}
 		return
 	}
+
 	if to.Document().LineComment == "" {
 		to.Document().LineComment = from.Document().LineComment
 	}
@@ -89,4 +122,40 @@ func copy(from, to *yaml.RNode) {
 	if to.Document().FootComment == "" {
 		to.Document().FootComment = from.Document().FootComment
 	}
+}
+
+// rememberLostComments goes through the comments attached to the from node
+// and adds them to the internal lostComments slice for usage after the tree
+// walk
+func (c *copier) rememberLostComments(from *yaml.RNode) {
+	fromName := from.Document().Value
+	fComments := []string{
+		from.Document().LineComment,
+		from.Document().HeadComment,
+		from.Document().FootComment,
+	}
+	for _, cStr := range fComments {
+		cStr = strings.TrimPrefix(cStr, "#")
+		cStr = strings.TrimSuffix(cStr, "\n")
+		cStr = strings.TrimSpace(cStr)
+
+		if cStr != "" {
+			c.lostComments = append(c.lostComments, lostComment{
+				fieldName: fromName,
+				comment:   cStr,
+			})
+		}
+	}
+}
+
+// restoreLostComments writes the cached lost comments to the top of the to
+// YAML tree
+func (c *copier) restoreLostComments(to *yaml.RNode) {
+	for i, c := range c.lostComments {
+		if i == 0 {
+			to.Document().HeadComment += "\nComments lost during file manipulation:"
+		}
+		to.Document().HeadComment += fmt.Sprintf("\n# Field name %q: %q", c.fieldName, c.comment)
+	}
+	to.Document().HeadComment = strings.TrimPrefix(to.Document().HeadComment, "\n")
 }

--- a/pkg/serializer/comments/comments_test.go
+++ b/pkg/serializer/comments/comments_test.go
@@ -325,6 +325,29 @@ data:
   somekey: "012345678901234567890123456789012345678901234567890123456789012345678901234" # x
 `,
 		},
+		{
+			name: "copy_comments_move_to_top",
+			from: `
+apiVersion: v1
+kind: ConfigMap # Foo
+# Bar
+data:
+  # Baz
+  somekey: "012345678901234567890123456789012345678901234567890123456789012345678901234" # x
+`,
+			to: `
+apiVersion: v1
+`,
+			expected: `
+# Comments lost during file manipulation:
+# Field name "data": "Bar"
+# Field name "somekey": "Baz"
+# Field name "012345678901234567890123456789012345678901234567890123456789012345678901234": "x"
+# Field name "ConfigMap": "Foo"
+
+apiVersion: v1
+`,
+		},
 	}
 
 	for i := range testCases {
@@ -340,7 +363,7 @@ data:
 				t.FailNow()
 			}
 
-			err = CopyComments(from, to)
+			err = CopyComments(from, to, true)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/pkg/serializer/comments/comments_test.go
+++ b/pkg/serializer/comments/comments_test.go
@@ -1,0 +1,358 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// This package provides a means to copy over comments between
+// two kyaml/yaml.RNode trees. This code is derived from
+// the sigs.k8s.io/kustomize/kyaml/comments package, at revision
+// 600d4f2c0bf174abd76d03e49939ee0c34b2a019.
+//
+// It has been slightly modified and adapted to not lose any
+// comment from the old tree, although the node the comment is
+// attached to doesn't exist in the new tree. To solve this,
+// this package moves any such comments to the beginning of the
+// file.
+// This file is a temporary means as long as we're waiting for
+// these code changes to get upstreamed to its origin, the kustomize repo.
+// https://pkg.go.dev/sigs.k8s.io/kustomize/kyaml/comments?tab=doc#CopyComments
+
+package comments
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func TestCopyComments(t *testing.T) {
+	testCases := []struct {
+		name     string
+		from     string
+		to       string
+		expected string
+	}{
+		{
+			name: "copy_comments",
+			from: `# A
+#
+# B
+
+# C
+apiVersion: apps/v1
+kind: Deployment
+spec: # comment 1
+  # comment 2
+  replicas: 3 # comment 3
+  # comment 4
+`,
+			to: `apiVersion: apps/v1
+kind: Deployment
+spec:
+  replicas: 4
+`,
+			expected: `# A
+#
+# B
+
+# C
+apiVersion: apps/v1
+kind: Deployment
+spec: # comment 1
+  # comment 2
+  replicas: 4 # comment 3
+  # comment 4
+`,
+		},
+
+		{
+			name: "associative_list",
+			from: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo
+        image: bar # comment 1
+`,
+			to: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo
+        image: bar
+`,
+			expected: `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: foo
+        image: bar # comment 1
+`,
+		},
+
+		{
+			name: "keep_comments",
+			from: `# A
+#
+# B
+
+# C
+apiVersion: apps/v1
+kind: Deployment
+spec: # comment 1
+  # comment 2
+  replicas: 3 # comment 3
+  # comment 4
+`,
+			to: `apiVersion: apps/v1
+kind: Deployment
+spec:
+  replicas: 4 # comment 5
+`,
+			expected: `# A
+#
+# B
+
+# C
+apiVersion: apps/v1
+kind: Deployment
+spec: # comment 1
+  # comment 2
+  replicas: 4 # comment 5
+  # comment 4
+`,
+		},
+
+		{
+			name: "copy_item_comments",
+			from: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- a # comment
+`,
+			to: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- a
+`,
+			expected: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- a # comment
+`,
+		},
+
+		{
+			name: "copy_item_comments_2",
+			from: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+# comment
+- a
+`,
+			to: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- a
+`,
+			expected: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+# comment
+- a
+`,
+		},
+
+		{
+			name: "copy_item_comments_middle",
+			from: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- a
+- b # comment
+- c
+`,
+			to: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- d
+- b
+- e
+`,
+			expected: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- d
+- b # comment
+- e
+`,
+		},
+
+		{
+			name: "copy_item_comments_moved",
+			from: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- a
+- b # comment
+- c
+`,
+			to: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- a
+- c
+- b
+`,
+			expected: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- a
+- c
+- b
+`,
+		},
+
+		{
+			name: "copy_item_comments_no_match",
+			from: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- a # comment
+`,
+			to: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- b
+`,
+			expected: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- b
+`,
+		},
+
+		{
+			name: "copy_item_comments_add",
+			from: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- a # comment
+`,
+			to: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- a
+- b
+`,
+			expected: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- a # comment
+- b
+`,
+		},
+
+		{
+			name: "copy_item_comments_remove",
+			from: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- a # comment
+- b
+`,
+			to: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- a
+`,
+			expected: `
+apiVersion: apps/v1
+kind: Deployment
+items:
+- a # comment
+`,
+		},
+
+		{
+			name: "copy_comments_folded_style",
+			from: `
+apiVersion: v1
+kind: ConfigMap
+data:
+  somekey: "012345678901234567890123456789012345678901234567890123456789012345678901234" # x
+`,
+			to: `
+apiVersion: v1
+kind: ConfigMap
+data:
+  somekey: >-
+    012345678901234567890123456789012345678901234567890123456789012345678901234
+`,
+			expected: `
+apiVersion: v1
+kind: ConfigMap
+data:
+  somekey: "012345678901234567890123456789012345678901234567890123456789012345678901234" # x
+`,
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			from, err := yaml.Parse(tc.from)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			to, err := yaml.Parse(tc.to)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			err = CopyComments(from, to)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			actual, err := to.String()
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			if !assert.Equal(t, strings.TrimSpace(tc.expected), strings.TrimSpace(actual)) {
+				t.FailNow()
+			}
+		})
+	}
+}


### PR DESCRIPTION
This implements the missing functionality in upstream `kyaml`.
I'll submit a similar PR to them and hope it will get accepted.
Meanwhile, I have included the attribution, license, and clearly made it visible in the git log what the changes are.

cc @stefanprodan @twelho @bboreham 