### PR TITLE
Handle the case where `in` already is the desired version when encoding

### DIFF
--- a/pkg/serializer/convertor.go
+++ b/pkg/serializer/convertor.go
@@ -215,6 +215,17 @@ func (c *objectConvertor) ConvertToVersion(in runtime.Object, groupVersioner run
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get GVK for hub: %w", err)
 	}
+
+	// If "in" already has the right, expected groupversion (here in the Encode CRD codepath),
+	// just return a deepcopy with its GVK set
+	if inGVK.GroupVersion().String() == gv.String() {
+		// Always make sure that the TypeMeta information is encoded.
+		// The Convert() call below also sets this information automatically
+		out := in.DeepCopyObject()
+		out.GetObjectKind().SetGroupVersionKind(inGVK)
+		return out, nil
+	}
+
 	// Assume the in and out (Hub and Convertible) kinds match (in encoded form)
 	outGVK := gv.WithKind(inGVK.Kind)
 

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -308,6 +308,13 @@ metadata:
 testString: foobar # Me too
 `)
 
+	oldCRDNoComments = []byte(`apiVersion: foogroup/v1alpha1
+kind: CRD
+metadata:
+  creationTimestamp: null
+testString: foobar
+`)
+
 	newCRD = []byte(`# I'm a top comment
 apiVersion: foogroup/v1alpha2
 kind: CRD
@@ -316,11 +323,20 @@ metadata:
 # Preserve me please!
 otherString: foobar # Me too
 `)
+
+	newCRDNoComments = []byte(`apiVersion: foogroup/v1alpha2
+kind: CRD
+metadata:
+  creationTimestamp: null
+otherString: foobar
+`)
 )
 
 func TestEncode(t *testing.T) {
 	simpleObj := &runtimetest.InternalSimple{TestString: "foo"}
 	complexObj := &runtimetest.InternalComplex{String: "bar"}
+	oldCRDObj := &CRDOldVersion{TestString: "foobar"}
+	newCRDObj := &CRDNewVersion{OtherString: "foobar"}
 	tests := []struct {
 		name        string
 		ct          ContentType
@@ -333,6 +349,8 @@ func TestEncode(t *testing.T) {
 		{"both simple and complex yaml", ContentTypeYAML, []runtime.Object{simpleObj, complexObj}, simpleAndComplex, false},
 		{"simple json", ContentTypeJSON, []runtime.Object{simpleObj}, simpleJSON, false},
 		{"complex json", ContentTypeJSON, []runtime.Object{complexObj}, complexJSON, false},
+		{"old CRD yaml", ContentTypeYAML, []runtime.Object{oldCRDObj}, oldCRDNoComments, false},
+		{"new CRD yaml", ContentTypeYAML, []runtime.Object{newCRDObj}, newCRDNoComments, false},
 		//{"no-conversion simple", defaultEncoder, &runtimetest.ExternalSimple{TestString: "foo"}, simpleJSON, false},
 		//{"support internal", defaultEncoder, []runtime.Object{simpleObj}, []byte(`{"testString":"foo"}` + "\n"), false},
 	}


### PR DESCRIPTION
cc @twelho 