### PR TITLE
Add CI support for testing via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,19 @@
+name: Continuous Integration
+on: [push, pull_request]
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+      - name: Docker Layer Caching
+        uses: satackey/action-docker-layer-caching@v0.0.3
+      - name: Restore Go Cache
+        uses: actions/cache@v2
+        with:
+          path: bin/cache/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-
+      - name: Run Unit Tests
+        run: make test


### PR DESCRIPTION
This add a CI workflow for GH Actions and some changes to the `Makefile` to work with it. Also exposes a new `make test` target, which will run the same test as the CI workflow locally in a container.

The tests don't yet pass, it seems like there's a lot of old cruft in there that will need to be taken care of in a subsequent PR.