### PR TITLE
Add a set of small Frame utils

### DIFF
--- a/pkg/serializer/frame_utils.go
+++ b/pkg/serializer/frame_utils.go
@@ -8,7 +8,8 @@ type FrameList [][]byte
 // ReadFrameList is a convenience method that reads all available frames from the FrameReader
 // into a returned FrameList
 func ReadFrameList(fr FrameReader) (FrameList, error) {
-	frameList := [][]byte{}
+	// TODO: Create an unit test for this function
+	var frameList [][]byte
 	for {
 		// Read until we get io.EOF or an error
 		frame, err := fr.ReadFrame()
@@ -25,6 +26,7 @@ func ReadFrameList(fr FrameReader) (FrameList, error) {
 
 // WriteFrameList is a convenience method that writes a set of frames to a FrameWriter
 func WriteFrameList(fw FrameWriter, frameList FrameList) error {
+	// TODO: Create an unit test for this function
 	// Loop all frames in the list, and write them individually to the FrameWriter
 	for _, frame := range frameList {
 		if _, err := fw.Write(frame); err != nil {

--- a/pkg/serializer/frame_utils.go
+++ b/pkg/serializer/frame_utils.go
@@ -1,0 +1,35 @@
+package serializer
+
+import "io"
+
+// FrameList is a list of frames (byte arrays), used for convenience functions
+type FrameList [][]byte
+
+// ReadFrameList is a convenience method that reads all available frames from the FrameReader
+// into a returned FrameList
+func ReadFrameList(fr FrameReader) (FrameList, error) {
+	frameList := [][]byte{}
+	for {
+		// Read until we get io.EOF or an error
+		frame, err := fr.ReadFrame()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+		// Append all frames to the returned list
+		frameList = append(frameList, frame)
+	}
+	return frameList, nil
+}
+
+// WriteFrameList is a convenience method that writes a set of frames to a FrameWriter
+func WriteFrameList(fw FrameWriter, frameList FrameList) error {
+	// Loop all frames in the list, and write them individually to the FrameWriter
+	for _, frame := range frameList {
+		if _, err := fw.Write(frame); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
These are generally useful when you don't want to write for loops reading frames and checking for io.EOF all the time (similar to `ioutil.ReadAll`, essentially)

cc @twelho 