### PR TITLE
Resolve correct field names for lost inline comments

### DIFF
--- a/pkg/serializer/comments/comments_test.go
+++ b/pkg/serializer/comments/comments_test.go
@@ -34,7 +34,8 @@ func TestCopyComments(t *testing.T) {
 	}{
 		{
 			name: "copy_comments",
-			from: `# A
+			from: `
+# A
 #
 # B
 
@@ -46,12 +47,14 @@ spec: # comment 1
   replicas: 3 # comment 3
   # comment 4
 `,
-			to: `apiVersion: apps/v1
+			to: `
+apiVersion: apps/v1
 kind: Deployment
 spec:
   replicas: 4
 `,
-			expected: `# A
+			expected: `
+# A
 #
 # B
 
@@ -63,9 +66,7 @@ spec: # comment 1
   replicas: 4 # comment 3
   # comment 4
 `,
-		},
-
-		{
+		}, {
 			name: "associative_list",
 			from: `
 apiVersion: apps/v1
@@ -97,11 +98,10 @@ spec:
       - name: foo
         image: bar # comment 1
 `,
-		},
-
-		{
+		}, {
 			name: "keep_comments",
-			from: `# A
+			from: `
+# A
 #
 # B
 
@@ -113,12 +113,14 @@ spec: # comment 1
   replicas: 3 # comment 3
   # comment 4
 `,
-			to: `apiVersion: apps/v1
+			to: `
+apiVersion: apps/v1
 kind: Deployment
 spec:
   replicas: 4 # comment 5
 `,
-			expected: `# A
+			expected: `
+# A
 #
 # B
 
@@ -130,9 +132,7 @@ spec: # comment 1
   replicas: 4 # comment 5
   # comment 4
 `,
-		},
-
-		{
+		}, {
 			name: "copy_item_comments",
 			from: `
 apiVersion: apps/v1
@@ -152,9 +152,7 @@ kind: Deployment
 items:
 - a # comment
 `,
-		},
-
-		{
+		}, {
 			name: "copy_item_comments_2",
 			from: `
 apiVersion: apps/v1
@@ -176,9 +174,7 @@ items:
 # comment
 - a
 `,
-		},
-
-		{
+		}, {
 			name: "copy_item_comments_middle",
 			from: `
 apiVersion: apps/v1
@@ -204,9 +200,7 @@ items:
 - b # comment
 - e
 `,
-		},
-
-		{
+		}, {
 			name: "copy_item_comments_moved",
 			from: `
 apiVersion: apps/v1
@@ -232,9 +226,7 @@ items:
 - c
 - b
 `,
-		},
-
-		{
+		}, {
 			name: "copy_item_comments_no_match",
 			from: `
 apiVersion: apps/v1
@@ -254,9 +246,7 @@ kind: Deployment
 items:
 - b
 `,
-		},
-
-		{
+		}, {
 			name: "copy_item_comments_add",
 			from: `
 apiVersion: apps/v1
@@ -278,9 +268,7 @@ items:
 - a # comment
 - b
 `,
-		},
-
-		{
+		}, {
 			name: "copy_item_comments_remove",
 			from: `
 apiVersion: apps/v1
@@ -301,9 +289,7 @@ kind: Deployment
 items:
 - a # comment
 `,
-		},
-
-		{
+		}, {
 			name: "copy_comments_folded_style",
 			from: `
 apiVersion: v1
@@ -324,10 +310,11 @@ kind: ConfigMap
 data:
   somekey: "012345678901234567890123456789012345678901234567890123456789012345678901234" # x
 `,
-		},
-		{
+		}, {
 			name: "copy_comments_move_to_top",
 			from: `
+# Top comment
+
 apiVersion: v1
 kind: ConfigMap # Foo
 # Bar
@@ -339,11 +326,12 @@ data:
 apiVersion: v1
 `,
 			expected: `
+# Top comment
 # Comments lost during file manipulation:
-# Field name "data": "Bar"
-# Field name "somekey": "Baz"
-# Field name "012345678901234567890123456789012345678901234567890123456789012345678901234": "x"
-# Field name "ConfigMap": "Foo"
+# Field "data": "Bar"
+# Field "somekey": "Baz"
+# Field "somekey": "x"
+# Field "kind": "Foo"
 
 apiVersion: v1
 `,

--- a/pkg/serializer/comments/lost.go
+++ b/pkg/serializer/comments/lost.go
@@ -1,0 +1,117 @@
+package comments
+
+import (
+	"fmt"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+	"strings"
+)
+
+// lostComment specifies a mapping between a fieldName (in the old structure), which doesn't exist in the
+// new tree, and its related comment. It optionally specifies the line number of the comment, a positive
+// line number is used to distinguish inline comments, which require special handling to resolve the
+// correct field name, since they are attached to the value and not the key of a YAML key-value pair.
+type lostComment struct {
+	fieldName string
+	comment   string
+	line      int
+}
+
+// Since the YAML walker needs to visit all keys as scalar nodes, we have no way of distinguishing keys from
+// values when trying to resolve the field names for inline comments. By tracking the leftmost key (lowest
+// column value, be it a key or value) for each row, we can figure out the actual key for inline comments
+// and not accidentally use a value as the field name, since keys are guaranteed to come before values.
+type trackedKey struct {
+	name   string
+	column int
+}
+
+// trackKey compares the column position of the given node to the stored best (lowest) column position for the
+// node's line and replaces the best if the given node is more likely to be a key (has a smaller column value).
+func (c *copier) trackKey(node *yaml.Node) {
+	// If the given key doesn't have a smaller column value, return.
+	if key, ok := c.trackedKeys[node.Line]; ok {
+		if key.column < node.Column {
+			return
+		}
+	}
+
+	// Store the new best tracked key for the line.
+	c.trackedKeys[node.Line] = trackedKey{
+		name:   node.Value,
+		column: node.Column,
+	}
+}
+
+// parseComments parses the line, head and foot comments of the given node in this
+// order and cleans them up (removes the potential "#" prefix and trims whitespace).
+func parseComments(node *yaml.Node) (comments []string) {
+	for _, comment := range []string{node.LineComment, node.HeadComment, node.FootComment} {
+		comments = append(comments, strings.TrimSpace(strings.TrimPrefix(comment, "#")))
+	}
+
+	return
+}
+
+// rememberLostComments goes through the comments attached to the 'from' node and adds
+// them to the internal lostComments slice for usage after the tree walk. It also
+// stores the line numbers for inline comments for resolving the correct field names.
+func (c *copier) rememberLostComments(from *yaml.RNode) {
+	// Track the given node as a potential key for inline comments.
+	c.trackKey(from.Document())
+
+	// Get the field name, for head/foot comments this is the correct key,
+	// but for inline comments this resolves to the value of the field instead.
+	fieldName := from.Document().Value
+	comments := parseComments(from.Document())
+	line := -1 // Don't store the line number of the comment by default, this is reserved for inline comments.
+
+	for i, comment := range comments {
+		// If the line number is set (positive), an inline comment
+		// has been registered for this node and we can stop parsing.
+		if line >= 0 {
+			break
+		}
+
+		// Do not store blank comment entries (nonexistent comments).
+		if len(comment) == 0 {
+			continue
+		}
+
+		if i == 0 {
+			// If this node has an inline comment, store its line
+			// number for resolving the correct field name later.
+			line = from.Document().Line
+		}
+
+		// Append the lost comment to the slice of copier.
+		c.lostComments = append(c.lostComments, lostComment{
+			fieldName: fieldName,
+			comment:   comment,
+			line:      line,
+		})
+	}
+}
+
+// restoreLostComments writes the cached lost comments to the top of the to YAML tree.
+// If it encounters inline comments, it will check the cached tracked keys for the
+// best key for the line on which the comment resided. If no key is found for some
+// reason, it will use the stored field name (the field value) as the key.
+func (c *copier) restoreLostComments(to *yaml.RNode) {
+	for i, lc := range c.lostComments {
+		if i == 0 {
+			to.Document().HeadComment += "\nComments lost during file manipulation:"
+		}
+
+		fieldName := lc.fieldName
+		if lc.line >= 0 {
+			// This is an inline comment, resolve the field name from the tracked keys.
+			if key, ok := c.trackedKeys[lc.line]; ok {
+				fieldName = key.name
+			}
+		}
+
+		to.Document().HeadComment += fmt.Sprintf("\n# Field %q: %q", fieldName, lc.comment)
+	}
+
+	to.Document().HeadComment = strings.TrimPrefix(to.Document().HeadComment, "\n")
+}


### PR DESCRIPTION
Since the YAML walker for preserving comments is built around dealing with keys as scalars, relational information is lost for key-value pairs. This causes inline comments to be "attached" to the nodes describing values instead of the nodes for the fields (the keys). This implementation uses the positional information stored in the YAML nodes to keep track of the best candidate for a key for each line, to later use that information to resolve the "best" field name for an inline comment on a specific line.

Also includes some formatting improvements for the comment tests, as well as changes `Field name` to just `Field` when moving lost comments to the top of the file.

Example of correct resolving of inline comments when transferring from
```
# Top comment

apiVersion: v1
kind: ConfigMap # Foo
# Bar
data:
  # Baz
  somekey: "012345678901234567890123456789012345678901234567890123456789012345678901234" # x
```
to
```
apiVersion: v1
```
:
```
# Top comment
# Comments lost during file manipulation:
# Field "data": "Bar"
# Field "somekey": "Baz"
# Field "somekey": "x" <-- "somekey" here instead of "0123456..."
# Field "kind": "Foo"

apiVersion: v1
```

cc @luxas 