### PR TITLE
High-level getter/setter for the YAML tree used for transferring comments 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ docker-%:
 
 test: docker-test-internal
 test-internal:
-	go test $(addsuffix /...,$(addprefix ./,${SRC_PKGS}))
+	go test -v $(addsuffix /...,$(addprefix ./,${SRC_PKGS}))
 
 tidy: docker-tidy-internal
 tidy-internal: /go/bin/goimports

--- a/pkg/serializer/comments/lost.go
+++ b/pkg/serializer/comments/lost.go
@@ -2,8 +2,9 @@ package comments
 
 import (
 	"fmt"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
 	"strings"
+
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 // lostComment specifies a mapping between a fieldName (in the old structure), which doesn't exist in the

--- a/pkg/serializer/comments_test.go
+++ b/pkg/serializer/comments_test.go
@@ -100,11 +100,14 @@ func TestGetCommentSource(t *testing.T) {
 				t.Errorf("expected error %t, but received %t: %v", tc.expectedErr, actualErr != nil, actualErr)
 			}
 
-			if actualErr == nil {
-				str, err := source.String()
-				require.NoError(t, err)
-				assert.Equal(t, tc.result, str)
+			if actualErr != nil {
+				// Already handled above.
+				return
 			}
+
+			str, err := source.String()
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, str)
 		})
 	}
 }
@@ -146,21 +149,24 @@ func TestSetCommentSource(t *testing.T) {
 				t.Errorf("expected error %t, but received %t: %v", tc.expectedErr, actualErr != nil, actualErr)
 			}
 
-			if actualErr == nil {
-				meta, ok := toMetaObject(tc.obj)
-				if !ok {
-					t.Fatal("cannot extract metav1.ObjectMeta")
-				}
-
-				annotation, ok := getAnnotation(meta, preserveCommentsAnnotation)
-				if !ok {
-					t.Fatal("expected annotation to be set, but it is not")
-				}
-
-				str, err := base64.StdEncoding.DecodeString(annotation)
-				require.NoError(t, err)
-				assert.Equal(t, tc.result, string(str))
+			if actualErr != nil {
+				// Already handled above.
+				return
 			}
+
+			meta, ok := toMetaObject(tc.obj)
+			if !ok {
+				t.Fatal("cannot extract metav1.ObjectMeta")
+			}
+
+			annotation, ok := getAnnotation(meta, preserveCommentsAnnotation)
+			if !ok {
+				t.Fatal("expected annotation to be set, but it is not")
+			}
+
+			str, err := base64.StdEncoding.DecodeString(annotation)
+			require.NoError(t, err)
+			assert.Equal(t, tc.result, string(str))
 		})
 	}
 }

--- a/pkg/serializer/comments_test.go
+++ b/pkg/serializer/comments_test.go
@@ -1,0 +1,196 @@
+package serializer
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	runtimetest "k8s.io/apimachinery/pkg/runtime/testing"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+const sampleData1 = `# Comment
+
+kind: Test
+spec:
+  # Head comment
+  data:
+  - field # Inline comment
+  - another
+  thing:
+    # Head comment
+    var: true
+`
+
+const sampleData2 = `kind: Test
+spec:
+  # Head comment
+  data:
+  - field # Inline comment
+  - another:
+      subthing: "yes"
+  thing:
+    # Head comment
+    var: true
+status:
+  nested:
+    fields:
+    # Just a comment
+`
+
+type internalSimpleOM struct {
+	runtimetest.InternalSimple
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+}
+
+func withComments(data string) *internalSimpleOM {
+	return &internalSimpleOM{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{preserveCommentsAnnotation: data},
+		},
+	}
+}
+
+func parseRNode(t *testing.T, source string) *yaml.RNode {
+	rNode, err := yaml.Parse(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return rNode
+}
+
+func TestGetCommentSource(t *testing.T) {
+	testCases := []struct {
+		name        string
+		obj         runtime.Object
+		result      string
+		expectedErr bool
+	}{
+		{
+			name:        "no_ObjectMeta",
+			obj:         &runtimetest.InternalSimple{},
+			expectedErr: true,
+		},
+		{
+			name:        "no_comments",
+			obj:         &internalSimpleOM{},
+			expectedErr: true,
+		},
+		{
+			name:        "invalid_comments",
+			obj:         withComments("ä"),
+			expectedErr: true,
+		},
+		{
+			name:        "successful_parsing",
+			obj:         withComments(base64.StdEncoding.EncodeToString([]byte(sampleData1))),
+			result:      sampleData1,
+			expectedErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			source, actualErr := GetCommentSource(tc.obj)
+			if (actualErr != nil) != tc.expectedErr {
+				t.Errorf("expected error %t, but received %t: %v", tc.expectedErr, actualErr != nil, actualErr)
+			}
+
+			if actualErr == nil {
+				str, err := source.String()
+				require.NoError(t, err)
+				assert.Equal(t, tc.result, str)
+			}
+		})
+	}
+}
+
+func TestSetCommentSource(t *testing.T) {
+	testCases := []struct {
+		name        string
+		obj         runtime.Object
+		source      *yaml.RNode
+		result      string
+		expectedErr bool
+	}{
+		{
+			name:        "no_ObjectMeta",
+			obj:         &runtimetest.InternalSimple{},
+			source:      yaml.NewScalarRNode("test"),
+			expectedErr: true,
+		},
+		{
+			name:        "nil_source",
+			obj:         &internalSimpleOM{},
+			source:      nil,
+			result:      "",
+			expectedErr: false,
+		},
+		{
+			name:        "successful_parsing",
+			obj:         &internalSimpleOM{},
+			source:      parseRNode(t, sampleData1),
+			result:      sampleData1,
+			expectedErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualErr := SetCommentSource(tc.obj, tc.source)
+			if (actualErr != nil) != tc.expectedErr {
+				t.Errorf("expected error %t, but received %t: %v", tc.expectedErr, actualErr != nil, actualErr)
+			}
+
+			if actualErr == nil {
+				meta, ok := toMetaObject(tc.obj)
+				if !ok {
+					t.Fatal("cannot extract metav1.ObjectMeta")
+				}
+
+				annotation, ok := getAnnotation(meta, preserveCommentsAnnotation)
+				if !ok {
+					t.Fatal("expected annotation to be set, but it is not")
+				}
+
+				str, err := base64.StdEncoding.DecodeString(annotation)
+				require.NoError(t, err)
+				assert.Equal(t, tc.result, string(str))
+			}
+		})
+	}
+}
+
+func TestCommentSourceSetGet(t *testing.T) {
+	testCases := []struct {
+		name   string
+		source string
+	}{
+		{
+			name:   "encode_decode_1",
+			source: sampleData1,
+		},
+		{
+			name:   "encode_decode_2",
+			source: sampleData2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &internalSimpleOM{}
+			assert.NoError(t, SetCommentSource(obj, parseRNode(t, tc.source)))
+
+			rNode, err := GetCommentSource(obj)
+			assert.NoError(t, err)
+
+			str, err := rNode.String()
+			require.NoError(t, err)
+			assert.Equal(t, tc.source, str)
+		})
+	}
+}

--- a/pkg/serializer/objectmeta.go
+++ b/pkg/serializer/objectmeta.go
@@ -49,7 +49,7 @@ func setAnnotation(metaObj metav1.Object, key, val string) {
 	}
 
 	// Set the key-value mapping and write back to the object
-	a[preserveCommentsAnnotation] = val
+	a[key] = val
 	// This wouldn't be needed if a was non-nil (as maps are reference types), but in the case
 	// of the map being nil, this is a must in order to apply the change
 	metaObj.SetAnnotations(a)

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -136,17 +136,17 @@ func addExternalTypes(extgv schema.GroupVersion) func(*runtime.Scheme) error {
 	}
 }
 
-func assert(err error) {
+func panicIfErr(err error) {
 	if err != nil {
 		panic(err)
 	}
 }
 
 func init() {
-	assert(intsb.AddToScheme(scheme))
-	assert(ext1sb.AddToScheme(scheme))
-	assert(ext2sb.AddToScheme(scheme))
-	assert(scheme.SetVersionPriority(ext1gv))
+	panicIfErr(intsb.AddToScheme(scheme))
+	panicIfErr(ext1sb.AddToScheme(scheme))
+	panicIfErr(ext2sb.AddToScheme(scheme))
+	panicIfErr(scheme.SetVersionPriority(ext1gv))
 }
 
 func registerOldCRD(scheme *runtime.Scheme) error {


### PR DESCRIPTION
Implements high-level `GetCommentSource` and `SetCommentSource` functions for accessing the `*yaml.RNode` tree used internally for transferring comments. This access enables applications pulling in `libgitops` to do advanced operations while still preserving comment transfer abilities, they can e.g. re-parent the comment source tree (move it under a sub-node) to match changes in the object's structure.

cc @luxas, feedback would be appreciated on whether you think these are sensible/in the right place/integrated well enough with the rest of the comment handling.