### PR TITLE
Add goreleaser for automatic release note generation

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -1,0 +1,35 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      # Similar to https://github.com/fluxcd/toolkit/blob/master/.github/workflows/release.yaml#L20-L27
+      - name: Download release notes utility
+        env:
+          GH_REL_URL: https://github.com/buchanae/github-release-notes/releases/download/0.2.0/github-release-notes-linux-amd64-0.2.0.tar.gz
+        run: cd /tmp && curl -sSL ${GH_REL_URL} | tar xz && sudo mv github-release-notes /usr/local/bin/
+      - name: Generate release notes
+        run: |
+          echo 'CHANGELOG' > /tmp/release.txt
+          github-release-notes -org weaveworks -repo libgitops -since-latest-release >> /tmp/release.txt
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --release-notes=/tmp/release.txt --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,11 @@
+# .goreleaser.yml
+project_name: libgitops
+
+# This is a library so we don't have any build targets, but having goreleaser automatically
+# generate release notes for us is nice.
+build:
+  skip: true
+
+# This automatically closes any milestone named the same as the tag
+milestones:
+  - close: true


### PR DESCRIPTION
We skip the automatic builds since this a library, but with this we get at least get automatic release note generation. Resolves #35.

cc @luxas 